### PR TITLE
Import Material icons and their dependencies

### DIFF
--- a/app/client/mindjogg/package.json
+++ b/app/client/mindjogg/package.json
@@ -12,6 +12,7 @@
     "lint": "npx eslint . --ext .js"
   },
   "dependencies": {
+    "@material-ui/core": "^4.12.3",
     "expo": "~44.0.0",
     "expo-status-bar": "~1.2.0",
     "react": "17.0.1",
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
+    "@material-ui/icons": "^4.11.2",
     "@testing-library/react-native": "^9.0.0",
     "eslint": "^8.7.0",
     "eslint-plugin-react": "^7.28.0",


### PR DESCRIPTION
# Pull Request Name
Install a library for icons

## Source 
Closes #35 

## Description 
Brings in Material UI core and Material icons

### Summary of PR  
Updates package.json to include Material UI

### Purpose 
Allow us to use Material, specifically Material's icons

## Review and Testing Steps
- [x] Pull this branch and run npm install
- [x] Follow the documentation [here ](https://github.com/UPEI-Android/group-project-mindjogg/wiki/Using-Material-UI-Icons) in any component to see icons in action

## Additional Information (If applicable)
Documentation has been added to the wiki

### Notes
N/A
