### PR TITLE
Meterial Bottom tab navigation

### DIFF
--- a/app/client/mindjogg/App.js
+++ b/app/client/mindjogg/App.js
@@ -4,12 +4,12 @@ import { NavigationContainer } from "@react-navigation/native";
 
 
 
-import SmartGoalStackNavigator from "./screens/navigation/SmartGoalStackNavigator";
+import AccountManagementTabNavigator from "./screens/navigation/AccountManagementTabNavigator";
 
 function App() {
   return (
     <NavigationContainer>
-      <SmartGoalStackNavigator />
+      <AccountManagementTabNavigator />
     </NavigationContainer>
   );
 }

--- a/app/client/mindjogg/package-lock.json
+++ b/app/client/mindjogg/package-lock.json
@@ -11,6 +11,7 @@
         "@material-ui/core": "^4.12.3",
         "@react-navigation/bottom-tabs": "^6.1.0",
         "@react-navigation/drawer": "^6.2.0",
+        "@react-navigation/material-bottom-tabs": "^6.1.1",
         "@react-navigation/native": "^6.0.7",
         "@react-navigation/native-stack": "^6.3.0",
         "expo": "~44.0.0",
@@ -18,8 +19,10 @@
         "react": "17.0.1",
         "react-dom": "17.0.1",
         "react-native": "0.64.3",
+        "react-native-paper": "^4.11.2",
         "react-native-safe-area-context": "3.3.2",
         "react-native-screens": "~3.10.1",
+        "react-native-vector-icons": "^9.0.0",
         "react-native-web": "0.17.1"
       },
       "devDependencies": {
@@ -1794,6 +1797,18 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@callstack/react-theme-provider": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.7.tgz",
+      "integrity": "sha512-Ab6rbD2w4u9W3yf7LQQ8evx9m8fZNsoWxt+MFm3AyZnyKQNCJf4K7ip9tHHZgSs+HTdoj38lEqPehvFOVQKvAg==",
+      "dependencies": {
+        "deepmerge": "^3.2.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
     },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
@@ -4944,14 +4959,30 @@
       }
     },
     "node_modules/@react-navigation/elements": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.0.tgz",
-      "integrity": "sha512-C0roIxajvleskEpeYYJ1+2XTg8UqZO6o/SyzqTRuEUVsVD8CbFzKSOfj9kpfzA7jbYNzZPbzUJcm9kIigY9kHg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.1.tgz",
+      "integrity": "sha512-jIDRJaG8YPIinl4hZXJu/W3TnhDe8hLYmGSEdL1mxZ1aoNMiApCBYkgTy11oq0EfK/koZd3DPSkJNbzBAQmPJw==",
       "peerDependencies": {
         "@react-navigation/native": "^6.0.0",
         "react": "*",
         "react-native": "*",
         "react-native-safe-area-context": ">= 3.0.0"
+      }
+    },
+    "node_modules/@react-navigation/material-bottom-tabs": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/material-bottom-tabs/-/material-bottom-tabs-6.1.1.tgz",
+      "integrity": "sha512-2qgBdiHOXMrjFszdXz6loNrjhPjdtunarbpsP6mzy2Dk8jZ5vL3G6v3sKiZ+eXUomw1ztulxuUfMnRqpy83wkQ==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.1"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-paper": ">= 3.0.0",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-vector-icons": ">= 6.0.0"
       }
     },
     "node_modules/@react-navigation/native": {
@@ -16127,6 +16158,29 @@
         "prop-types": "^15.7.2"
       }
     },
+    "node_modules/react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "peerDependencies": {
+        "react-native": ">=0.42.0"
+      }
+    },
+    "node_modules/react-native-paper": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-4.11.2.tgz",
+      "integrity": "sha512-r+M5unY9Avez4we/RijVh4iy8gqxK93R4840aZmbakOJLIuxjfNh3B6SuoxBEbR6diuPRbKVeWHKju4mhltxWw==",
+      "dependencies": {
+        "@callstack/react-theme-provider": "^3.0.7",
+        "color": "^3.1.2",
+        "react-native-iphone-x-helper": "^1.3.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-vector-icons": "*"
+      }
+    },
     "node_modules/react-native-reanimated": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.3.1.tgz",
@@ -16167,6 +16221,125 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-vector-icons": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.0.0.tgz",
+      "integrity": "sha512-qKX5d5/TafHmI4B7UOSZCL3BAGh7ZfF30iLwRgxBkKfZl2lKSuHp8Ottj9OyWh9b5fFtlg+LtyvZrns3g2kh+w==",
+      "dependencies": {
+        "lodash.frompairs": "^4.0.1",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isstring": "^4.0.1",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "lodash.template": "^4.5.0",
+        "prop-types": "^15.7.2",
+        "yargs": "^16.1.1"
+      },
+      "bin": {
+        "fa5-upgrade": "bin/fa5-upgrade.sh",
+        "generate-icon": "bin/generate-icon.js"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/react-native-vector-icons/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native-web": {
@@ -19826,6 +19999,15 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@callstack/react-theme-provider": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.7.tgz",
+      "integrity": "sha512-Ab6rbD2w4u9W3yf7LQQ8evx9m8fZNsoWxt+MFm3AyZnyKQNCJf4K7ip9tHHZgSs+HTdoj38lEqPehvFOVQKvAg==",
+      "requires": {
+        "deepmerge": "^3.2.0",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -22227,10 +22409,18 @@
       }
     },
     "@react-navigation/elements": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.0.tgz",
-      "integrity": "sha512-C0roIxajvleskEpeYYJ1+2XTg8UqZO6o/SyzqTRuEUVsVD8CbFzKSOfj9kpfzA7jbYNzZPbzUJcm9kIigY9kHg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.1.tgz",
+      "integrity": "sha512-jIDRJaG8YPIinl4hZXJu/W3TnhDe8hLYmGSEdL1mxZ1aoNMiApCBYkgTy11oq0EfK/koZd3DPSkJNbzBAQmPJw==",
       "requires": {}
+    },
+    "@react-navigation/material-bottom-tabs": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/material-bottom-tabs/-/material-bottom-tabs-6.1.1.tgz",
+      "integrity": "sha512-2qgBdiHOXMrjFszdXz6loNrjhPjdtunarbpsP6mzy2Dk8jZ5vL3G6v3sKiZ+eXUomw1ztulxuUfMnRqpy83wkQ==",
+      "requires": {
+        "@react-navigation/elements": "^1.3.1"
+      }
     },
     "@react-navigation/native": {
       "version": "6.0.7",
@@ -30908,6 +31098,22 @@
         "prop-types": "^15.7.2"
       }
     },
+    "react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "requires": {}
+    },
+    "react-native-paper": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-4.11.2.tgz",
+      "integrity": "sha512-r+M5unY9Avez4we/RijVh4iy8gqxK93R4840aZmbakOJLIuxjfNh3B6SuoxBEbR6diuPRbKVeWHKju4mhltxWw==",
+      "requires": {
+        "@callstack/react-theme-provider": "^3.0.7",
+        "color": "^3.1.2",
+        "react-native-iphone-x-helper": "^1.3.1"
+      }
+    },
     "react-native-reanimated": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.3.1.tgz",
@@ -30936,6 +31142,96 @@
       "requires": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
+      }
+    },
+    "react-native-vector-icons": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.0.0.tgz",
+      "integrity": "sha512-qKX5d5/TafHmI4B7UOSZCL3BAGh7ZfF30iLwRgxBkKfZl2lKSuHp8Ottj9OyWh9b5fFtlg+LtyvZrns3g2kh+w==",
+      "requires": {
+        "lodash.frompairs": "^4.0.1",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isstring": "^4.0.1",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "lodash.template": "^4.5.0",
+        "prop-types": "^15.7.2",
+        "yargs": "^16.1.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+        }
       }
     },
     "react-native-web": {

--- a/app/client/mindjogg/package.json
+++ b/app/client/mindjogg/package.json
@@ -15,6 +15,7 @@
     "@material-ui/core": "^4.12.3",
     "@react-navigation/bottom-tabs": "^6.1.0",
     "@react-navigation/drawer": "^6.2.0",
+    "@react-navigation/material-bottom-tabs": "^6.1.1",
     "@react-navigation/native": "^6.0.7",
     "@react-navigation/native-stack": "^6.3.0",
     "expo": "~44.0.0",
@@ -22,8 +23,10 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-native": "0.64.3",
+    "react-native-paper": "^4.11.2",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.10.1",
+    "react-native-vector-icons": "^9.0.0",
     "react-native-web": "0.17.1"
   },
   "devDependencies": {

--- a/app/client/mindjogg/screens/navigation/AccountManagementStackNavigator.js
+++ b/app/client/mindjogg/screens/navigation/AccountManagementStackNavigator.js
@@ -1,4 +1,5 @@
 import React from "react";
+import {View} from "react-native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
 // import SignInScreen and SingUpScreen from the account_management folder
@@ -10,6 +11,7 @@ const Stack = createNativeStackNavigator();
 const AccountManagementStackNavigator = () => {
   return (
 
+    <View style={{ flex: 1 }} collapsable={false}>
     <Stack.Navigator initialRouteName="SignIn"
     screenOptions={{
         headerStyle: {
@@ -22,6 +24,7 @@ const AccountManagementStackNavigator = () => {
         <Stack.Screen name="SignIn" component={SignInScreen} />
         <Stack.Screen name="SignUp" component={SignUpScreen} />
     </Stack.Navigator>
+    </View>
   );
 }
 

--- a/app/client/mindjogg/screens/navigation/AccountManagementTabNavigator.js
+++ b/app/client/mindjogg/screens/navigation/AccountManagementTabNavigator.js
@@ -1,0 +1,62 @@
+import { createMaterialBottomTabNavigator } from "@react-navigation/material-bottom-tabs";
+import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons";
+
+import AccountManagementStackNavigator from "./AccountManagementStackNavigator";
+import EmergencySupportStackNavigator from "./EmergencySupportStackNavigator";
+import PositviJournalStackNavigator from "./PositiveJournalStackNavigator";
+import SmartGoalStackNavigator from "./SmartGoalStackNavigator";
+
+const Tab = createMaterialBottomTabNavigator();
+
+const AccountManagementTabNavigator = () => {
+    return (
+      <Tab.Navigator
+       
+        activeColor="#e91e63"
+        barStyle={{ backgroundColor: "tomato" }}
+      >
+        <Tab.Screen
+          name="Feed"
+          component={AccountManagementStackNavigator}
+          options={{
+            tabBarLabel: "Home",
+            tabBarIcon: ({ color }) => (
+              <MaterialCommunityIcons name="home" color={color} size={26} />
+            ),
+          }}
+        />
+        <Tab.Screen
+          name="Notifications"
+          component={EmergencySupportStackNavigator}
+          options={{
+            tabBarLabel: "Updates",
+            tabBarIcon: ({ color }) => (
+              <MaterialCommunityIcons name="bell" color={color} size={26} />
+            ),
+          }}
+        />
+        <Tab.Screen
+          name="Profile"
+          component={PositviJournalStackNavigator}
+          options={{
+            tabBarLabel: "Profile",
+            tabBarIcon: ({ color }) => (
+              <MaterialCommunityIcons name="account" color={color} size={26} />
+            ),
+          }}
+        />
+        <Tab.Screen
+          name="Goals"
+          component={SmartGoalStackNavigator}
+          options={{
+            tabBarLabel: "Smart Goals",
+            tabBarIcon: ({ color }) => (
+              <MaterialCommunityIcons name="bell" color={color} size={26} />
+            ),
+          }}
+        />
+      </Tab.Navigator>
+    );
+}
+
+export default AccountManagementTabNavigator;

--- a/app/client/mindjogg/screens/navigation/AccountManagementTabNavigator.js
+++ b/app/client/mindjogg/screens/navigation/AccountManagementTabNavigator.js
@@ -1,3 +1,4 @@
+import React from "react";
 import { createMaterialBottomTabNavigator } from "@react-navigation/material-bottom-tabs";
 import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons";
 

--- a/app/client/mindjogg/screens/navigation/EmergencySupportStackNavigator.js
+++ b/app/client/mindjogg/screens/navigation/EmergencySupportStackNavigator.js
@@ -1,4 +1,5 @@
 import React from "react";
+import {View} from "react-native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
 // import EmergencySupportMainScreen, EmergencySupportListScreen, EmergencySupportDescriptionScreen from the emergency_support folder
@@ -12,6 +13,7 @@ const Stack = createNativeStackNavigator();
 const EmergencySupportStackNavigator = () => {
   return (
 
+    <View style={{ flex: 1 }} collapsable={false}>
     <Stack.Navigator initialRouteName="EmergencySupportMainScreen"
     screenOptions={{
         headerStyle: {
@@ -25,6 +27,7 @@ const EmergencySupportStackNavigator = () => {
         <Stack.Screen name="EmergencySupportListScreen" component={EmergencySupportListScreen} />
         <Stack.Screen name="EmergencySupportDescriptionScreen" component={EmergencySupportDescriptionScreen} />
     </Stack.Navigator>
+    </View>
   );
 }
 

--- a/app/client/mindjogg/screens/navigation/EmergencySupportTabNavigator.js
+++ b/app/client/mindjogg/screens/navigation/EmergencySupportTabNavigator.js
@@ -9,10 +9,10 @@ import SmartGoalStackNavigator from "./SmartGoalStackNavigator";
 
 const Tab = createMaterialBottomTabNavigator();
 
-const AccountManagementTabNavigator = () => {
+const EmergencySupportTabNavigator = () => {
     return (
       <Tab.Navigator
-        initialRouteName="Profile"
+        initialRouteName="Support"
         activeColor="#734f96"
         barStyle={{ backgroundColor: "white" }}
       >
@@ -60,4 +60,4 @@ const AccountManagementTabNavigator = () => {
     );
 }
 
-export default AccountManagementTabNavigator;
+export default EmergencySupportTabNavigator;

--- a/app/client/mindjogg/screens/navigation/PositiveJournalStackNavigator.js
+++ b/app/client/mindjogg/screens/navigation/PositiveJournalStackNavigator.js
@@ -1,5 +1,5 @@
 import React from "react";
-
+import {View} from "react-native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
 // import PositiveJournalMainScreen, PositiveJournalEditScreen from the positive_journal folder
@@ -12,6 +12,7 @@ const Stack = createNativeStackNavigator();
 const PositiveJournalStackNavigator = () => {
   return (
 
+    <View style={{ flex: 1 }} collapsable={false}>
     <Stack.Navigator initialRouteName="EmergencySupportMainScreen"
     screenOptions={{
         headerStyle: {
@@ -24,6 +25,7 @@ const PositiveJournalStackNavigator = () => {
         <Stack.Screen name="PositiveJournalMainScreen" component={PositiveJournalMainScreen} />
         <Stack.Screen name="PositiveJournalEditScreen" component={PositiveJournalEditScreen} />
     </Stack.Navigator>
+    </View>
   );
 }
 

--- a/app/client/mindjogg/screens/navigation/PositiveJournalTabNavigator.js
+++ b/app/client/mindjogg/screens/navigation/PositiveJournalTabNavigator.js
@@ -9,10 +9,10 @@ import SmartGoalStackNavigator from "./SmartGoalStackNavigator";
 
 const Tab = createMaterialBottomTabNavigator();
 
-const AccountManagementTabNavigator = () => {
+const PositiveJournalTabNavigator = () => {
     return (
       <Tab.Navigator
-        initialRouteName="Profile"
+        initialRouteName="Journal"
         activeColor="#734f96"
         barStyle={{ backgroundColor: "white" }}
       >
@@ -60,4 +60,4 @@ const AccountManagementTabNavigator = () => {
     );
 }
 
-export default AccountManagementTabNavigator;
+export default PositiveJournalTabNavigator;

--- a/app/client/mindjogg/screens/navigation/SmartGoalStackNavigator.js
+++ b/app/client/mindjogg/screens/navigation/SmartGoalStackNavigator.js
@@ -1,5 +1,5 @@
 import React from "react";
-
+import {View} from "react-native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
 // import SmartGoalMainScreen, SmartGoalEditScreen from the smart_goals folder
@@ -12,6 +12,7 @@ const Stack = createNativeStackNavigator();
 const SmartGoalStackNavigator = () => {
   return (
 
+    <View style={{ flex: 1 }} collapsable={false}>
     <Stack.Navigator initialRouteName="EmergencySupportMainScreen"
     screenOptions={{
         headerStyle: {
@@ -24,6 +25,7 @@ const SmartGoalStackNavigator = () => {
         <Stack.Screen name="SmartGoalMainScreen" component={SmartGoalMainScreen} />
         <Stack.Screen name="SmartGoalEditScreen" component={SmartGoalEditScreen} />
     </Stack.Navigator>
+    </View>
   );
 }
 

--- a/app/client/mindjogg/screens/navigation/SmartGoalTabNavigator.js
+++ b/app/client/mindjogg/screens/navigation/SmartGoalTabNavigator.js
@@ -9,10 +9,10 @@ import SmartGoalStackNavigator from "./SmartGoalStackNavigator";
 
 const Tab = createMaterialBottomTabNavigator();
 
-const AccountManagementTabNavigator = () => {
+const SmartGoalTabNavigator = () => {
     return (
       <Tab.Navigator
-        initialRouteName="Profile"
+        initialRouteName="Goals"
         activeColor="#734f96"
         barStyle={{ backgroundColor: "white" }}
       >
@@ -60,4 +60,4 @@ const AccountManagementTabNavigator = () => {
     );
 }
 
-export default AccountManagementTabNavigator;
+export default SmartGoalTabNavigator;

--- a/app/client/mindjogg/yarn.lock
+++ b/app/client/mindjogg/yarn.lock
@@ -1063,6 +1063,14 @@
   "resolved" "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   "version" "0.2.3"
 
+"@callstack/react-theme-provider@^3.0.7":
+  "integrity" "sha512-Ab6rbD2w4u9W3yf7LQQ8evx9m8fZNsoWxt+MFm3AyZnyKQNCJf4K7ip9tHHZgSs+HTdoj38lEqPehvFOVQKvAg=="
+  "resolved" "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.7.tgz"
+  "version" "3.0.7"
+  dependencies:
+    "deepmerge" "^3.2.0"
+    "hoist-non-react-statics" "^3.3.0"
+
 "@cnakazawa/watch@^1.0.3":
   "integrity" "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ=="
   "resolved" "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz"
@@ -1697,10 +1705,17 @@
     "color" "^3.1.3"
     "warn-once" "^0.1.0"
 
-"@react-navigation/elements@^1.3.0":
-  "integrity" "sha512-C0roIxajvleskEpeYYJ1+2XTg8UqZO6o/SyzqTRuEUVsVD8CbFzKSOfj9kpfzA7jbYNzZPbzUJcm9kIigY9kHg=="
-  "resolved" "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.0.tgz"
-  "version" "1.3.0"
+"@react-navigation/elements@^1.3.0", "@react-navigation/elements@^1.3.1":
+  "integrity" "sha512-jIDRJaG8YPIinl4hZXJu/W3TnhDe8hLYmGSEdL1mxZ1aoNMiApCBYkgTy11oq0EfK/koZd3DPSkJNbzBAQmPJw=="
+  "resolved" "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.1.tgz"
+  "version" "1.3.1"
+
+"@react-navigation/material-bottom-tabs@^6.1.1":
+  "integrity" "sha512-2qgBdiHOXMrjFszdXz6loNrjhPjdtunarbpsP6mzy2Dk8jZ5vL3G6v3sKiZ+eXUomw1ztulxuUfMnRqpy83wkQ=="
+  "resolved" "https://registry.npmjs.org/@react-navigation/material-bottom-tabs/-/material-bottom-tabs-6.1.1.tgz"
+  "version" "6.1.1"
+  dependencies:
+    "@react-navigation/elements" "^1.3.1"
 
 "@react-navigation/native-stack@^6.3.0":
   "integrity" "sha512-qH+zBkEzIFQSqeww1RUOVlMVNGtv1zZ+tSsePn82SBEjQ8nIM1zpI70nG+q+upaWI5C8YKmKouTt4Krdcrludg=="
@@ -2739,7 +2754,7 @@
     "color-name" "^1.0.0"
     "simple-swizzle" "^0.2.2"
 
-"color@^3.1.3":
+"color@^3.1.2", "color@^3.1.3":
   "integrity" "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA=="
   "resolved" "https://registry.npmjs.org/color/-/color-3.2.1.tgz"
   "version" "3.2.1"
@@ -6621,6 +6636,20 @@
     "lodash" "^4.17.21"
     "prop-types" "^15.7.2"
 
+"react-native-iphone-x-helper@^1.3.1":
+  "integrity" "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg=="
+  "resolved" "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz"
+  "version" "1.3.1"
+
+"react-native-paper@^4.11.2", "react-native-paper@>= 3.0.0":
+  "integrity" "sha512-r+M5unY9Avez4we/RijVh4iy8gqxK93R4840aZmbakOJLIuxjfNh3B6SuoxBEbR6diuPRbKVeWHKju4mhltxWw=="
+  "resolved" "https://registry.npmjs.org/react-native-paper/-/react-native-paper-4.11.2.tgz"
+  "version" "4.11.2"
+  dependencies:
+    "@callstack/react-theme-provider" "^3.0.7"
+    "color" "^3.1.2"
+    "react-native-iphone-x-helper" "^1.3.1"
+
 "react-native-reanimated@>= 1.0.0":
   "integrity" "sha512-nzjVqwkB8eeyPKT2KoiA9EEz17ZMFSGMoOTC17Z9b5nE2Z4ZHjHM5EKhY0TlwzXFUuJAE9PhOfxF0wIO/maZSA=="
   "resolved" "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.3.1.tgz"
@@ -6647,6 +6676,20 @@
     "react-freeze" "^1.0.0"
     "warn-once" "^0.1.0"
 
+"react-native-vector-icons@*", "react-native-vector-icons@^9.0.0", "react-native-vector-icons@>= 6.0.0":
+  "integrity" "sha512-qKX5d5/TafHmI4B7UOSZCL3BAGh7ZfF30iLwRgxBkKfZl2lKSuHp8Ottj9OyWh9b5fFtlg+LtyvZrns3g2kh+w=="
+  "resolved" "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.0.0.tgz"
+  "version" "9.0.0"
+  dependencies:
+    "lodash.frompairs" "^4.0.1"
+    "lodash.isequal" "^4.5.0"
+    "lodash.isstring" "^4.0.1"
+    "lodash.omit" "^4.5.0"
+    "lodash.pick" "^4.4.0"
+    "lodash.template" "^4.5.0"
+    "prop-types" "^15.7.2"
+    "yargs" "^16.1.1"
+
 "react-native-web@0.17.1":
   "integrity" "sha512-lUnn+2O8ynQ6/gJKylSxm7DLi2vHw6AujdDV1+LSa8Epe1bYFJNUcJTEhJf0jNYUFGOujzMtuG8Mkz3HdWTkag=="
   "resolved" "https://registry.npmjs.org/react-native-web/-/react-native-web-0.17.1.tgz"
@@ -6660,7 +6703,7 @@
     "normalize-css-color" "^1.0.2"
     "prop-types" "^15.6.0"
 
-"react-native@*", "react-native@>=0.59", "react-native@>=0.64.0-rc.0 || 0.0.0-*", "react-native@0.64.3":
+"react-native@*", "react-native@>=0.42.0", "react-native@>=0.59", "react-native@>=0.64.0-rc.0 || 0.0.0-*", "react-native@0.64.3":
   "integrity" "sha512-2OEU74U0Ek1/WeBzPbg6XDsCfjF/9fhrNX/5TFgEiBKd5mNc9LOZ/OlMmkb7iues/ZZ/oc51SbEfLRQdcW0fVw=="
   "resolved" "https://registry.npmjs.org/react-native/-/react-native-0.64.3.tgz"
   "version" "0.64.3"
@@ -6731,7 +6774,7 @@
     "loose-envify" "^1.4.0"
     "prop-types" "^15.6.2"
 
-"react@*", "react@^16.0.0 || ^17.0.0", "react@^16.8.0 || ^17.0.0", "react@^17.0.0", "react@>=16.0.0", "react@>=16.6.0", "react@>=17.0.1", "react@17.0.1", "react@17.0.2":
+"react@*", "react@^16.0.0 || ^17.0.0", "react@^16.8.0 || ^17.0.0", "react@^17.0.0", "react@>=16.0.0", "react@>=16.3.0", "react@>=16.6.0", "react@>=17.0.1", "react@17.0.1", "react@17.0.2":
   "integrity" "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w=="
   "resolved" "https://registry.npmjs.org/react/-/react-17.0.1.tgz"
   "version" "17.0.1"
@@ -8200,6 +8243,19 @@
     "which-module" "^2.0.0"
     "y18n" "^4.0.0"
     "yargs-parser" "^18.1.2"
+
+"yargs@^16.1.1":
+  "integrity" "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="
+  "resolved" "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
+  "version" "16.2.0"
+  dependencies:
+    "cliui" "^7.0.2"
+    "escalade" "^3.1.1"
+    "get-caller-file" "^2.0.5"
+    "require-directory" "^2.1.1"
+    "string-width" "^4.2.0"
+    "y18n" "^5.0.5"
+    "yargs-parser" "^20.2.2"
 
 "yargs@^16.2.0":
   "integrity" "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="


### PR DESCRIPTION
## Source 
Closes #110 

### Summary of PR 

The PR introduce material bottom tab navigation for the MindJoGG 
 
### Review and Testing Steps

1.Pull this branch
2. Run  ``` cd app/client/mindjogg ```
3. create a .env file and get the values from the shared doc
4. run ``` npm install```
5. run ```npm start```
6. You will see the bottom navbar 
7. check if all screens are accessible or not 
  

### Additional Information (If applicable)
The account management tab navigator will be removed later
It is not regular bottom tab navigation it is material bottom tab navigation. Learn more:  https://reactnavigation.org/docs/material-bottom-tab-navigator/

### Notes

There are an issue for android phone but it has been tackled for now using a view wrapper outside stack navigator but should be change when there is an update. Learn more about the issue: https://github.com/software-mansion/react-native-screens/issues/1197, https://github.com/callstack/react-native-paper/issues/2993